### PR TITLE
Updated the prompt to include the repository URL

### DIFF
--- a/autocommit/llm.py
+++ b/autocommit/llm.py
@@ -21,8 +21,8 @@ class CustomPromptTemplate(BasePromptTemplate, BaseModel):
 
 
 prompt = CustomPromptTemplate(
-    input_variables=["diff"], template="""
-    What follows "-------" is a git diff for a potential commit.
+    input_variables=["diff", "repo_url"], template="""
+    What follows "-------" is a git diff for a potential commit on the repository located at {repo_url}.
     Reply with a markdown unordered list of 5 possible, different Git commit messages 
     (a Git commit message should be concise but also try to describe 
     the important changes in the commit), order the list by what you think 
@@ -34,13 +34,13 @@ prompt = CustomPromptTemplate(
 """)
 
 
-def generate_suggestions(diff, openai_api_key=OPENAI_KEY):
+def generate_suggestions(diff, repo_url, openai_api_key=OPENAI_KEY):
 
     llm = OpenAI(temperature=0.2, openai_api_key=openai_api_key,
                  max_tokens=100, model_name="text-davinci-003")  # type: ignore
 
     # query OpenAI
-    formattedPrompt = prompt.format(diff=diff)
+    formattedPrompt = prompt.format(diff=diff, repo_url=repo_url)
     response = llm(formattedPrompt)
 
     # Convert the markdown string to HTML

--- a/scan_repo.py
+++ b/scan_repo.py
@@ -52,7 +52,7 @@ for commit in filtered_commit_objects:
     # text-davinci-003 supports 4000 tokens. Let's use upto 3500 tokens for the prompt.
     # 3500 tokens = 14,000 characters (https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them)
     # But in practice, > 7000 seems to exceed the limit
-    suggestions = generate_suggestions(commit.diff[:7000])
+    suggestions = generate_suggestions(commit.diff[:7000], GIT_REPO_URL)
 
     # generate CSV row
     for item in suggestions:


### PR DESCRIPTION
This pull request adds the repository origin as a parameter to the prompt template to eliminate the need to manually remove the "GitHub Repository URL" from the generated commit messages.